### PR TITLE
Mantis 1.3.x installation + french translation

### DIFF
--- a/FilterBugList.php
+++ b/FilterBugList.php
@@ -1,6 +1,6 @@
 <?php
-# MantisBT - a php based bugtracking system
-# Copyright (C) 2002 - 2011  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+# MantisBT - A PHP based bugtracking system
+
 # MantisBT is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or

--- a/FilterBugList.php
+++ b/FilterBugList.php
@@ -28,7 +28,7 @@ class FilterBugListPlugin extends MantisPlugin  {
         
         $this->version = '1.0.0';
         $this->requires = array(
-        	'MantisCore' => '1.2.0'
+        	'MantisCore' => '1.3.0'
         );
         
         $this->author = 'Alain D\'EURVEILHER';

--- a/classes/FilterBugListField.class.php
+++ b/classes/FilterBugListField.class.php
@@ -1,4 +1,18 @@
 <?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 class FilterBugListField extends MantisFilter {
 

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1,21 +1,18 @@
 <?php
-/** MantisBT - a php based bugtracking system
- *
- * Copyright (C) 2002 - 2011  MantisBT Team - mantisbt-dev@lists.sourceforge.net
- *
- * MantisBT is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * MantisBT is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
- */
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /** English (English)
  *

--- a/lang/strings_french.txt
+++ b/lang/strings_french.txt
@@ -1,0 +1,32 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/** Français (French)
+ *
+ * See the qqq 'language' for message documentation incl. usage of parameters
+ * To improve a translation please visit http://translatewiki.net
+ *
+ * @ingroup Language
+ * @file
+ *
+ * @author mr.bricodage@gmail.com
+ */
+
+$s_plugin_FilterBugList_title = 'Filtrage d\'une liste de bogues ';
+$s_plugin_FilterBugList_description = 'Permet de filtrer des bogues à partir d\'une liste d\'identifiants';
+$s_plugin_FilterBugList_field_label = 'Liste d\'identifiants';
+
+?>


### PR DESCRIPTION
Minor modifications to able installation of this plugin in Mantis v1.3.x.
French lang file has been added too.

The plugin works with current Mantis code (1.3.2).

The plugin seems to be compatible with future modifications from mantisbt PR #862, but could / should be modified to use the new filter_api.
